### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "shifter/cli",
     "description": "WP-CLI commands for the Shifter",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/getshifter/wp-cli-shifter",
     "license": "GPL-2.0",
     "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
