### PR TITLE
#11 update login api error response on tests code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 before_script:
 - bash bin/install-wp-tests.sh wordpress_test root '' localhost latest
 - WP_CLI_BIN_DIR=/tmp/wp-cli-phar bash bin/install-package-tests.sh
-script: phpunit && WP_CLI_BIN_DIR=/tmp/wp-cli-phar ./vendor/bin/behat
+- composer install
+script: ./vendor/bin/phpunit && WP_CLI_BIN_DIR=/tmp/wp-cli-phar ./vendor/bin/behat
 env:
   secure: oI2JoNEqiB4I9gszAoI2l6An5rO5z7sDAsShIECe1vEstToV6+ZnADxxSPsl5ZMHe18n4LTKtapx8rPdbMjJcukj1psLhyFbkaxQ7CaaLlWs2B+XqVWJywU9qdHjCbwRpvGm7IuviBLQMXK89vji92Hmt1P8rZXeiwXd/WhG4zsBl+f2NuPV0VkHa0i8f86CidYbV11ilncovJZYbd+yS4vZdLSL7QpKuF85vqzN74Qmd61ol66FYj/vVkb+TGK1xdemUlXHb9QAQWMOhyPLk7aLXgFKZtpm2BIwwDMKMyPX1YHztTzGYQXySi5gxI5t+qivfjGscQR4TzL1bMgkJCaZjAa3C1QUx2n6tOEkUflD4bE++Zc0+xa0wJ2qEJNLXUPhQT6Cn1Qg2BljZ923EZ/iKJfh/0QQrW7yAjtF0Os8JMOTp13PL9yE63G/myA7OhUfWjO7Dm3EYS2BCfyNx9Fvr/eJuHuG9eJNyVamHOUIgpC2698p8jDkAqpom/vzKg5EtVQbrnhSKuzeYCu/CNz7+i6T1ij6JCFQfId94JhBuo1aobPho8RMrIBHypW+OQ4EnQYtttfmtgQjgZH4+0nmhs2y/6qu9Fmi8Au0lJVkhs0aQzOVQR25azUipMVklOnytS4k4yJvSG+fv0fESdrG5wfX2U5eokbPBQpbXQw=

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.4"
     },
     "require-dev": {
-        "behat/behat": "~2.5"
+        "behat/behat": "~2.5",
+        "phpunit/phpunit": "5.6"
     }
 }

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -116,12 +116,11 @@ Feature: Test that `wp shifter archive` commands loads.
     When I try `wp shifter archive delete xxxx --shifter-user=xxxx --shifter-password=xxxx`
     Then STDERR should contain:
       """
-      Error: User does not exist.
+      Invalid Username or Password
       """
 
     When I try `wp shifter archive upload --shifter-user=xxxx --shifter-password=xxxx`
     Then STDERR should contain:
       """
-      Error: User does not exist.
+      Invalid Username or Password
       """
-

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -22,11 +22,11 @@ class SimpleMapTest extends WP_UnitTestCase
 	{
 		$res = Functions::auth( "foo", "bar" );
 		$this->assertTrue( Error::is_error( $res ) );
-		$this->assertSame( 'User does not exist.', $res->get_message() );
+		$this->assertSame( 'Invalid Username or Password', $res->get_message() );
 
 		$res = Functions::auth( getenv( "SHIFTER_USER" ), "bar" );
 		$this->assertTrue( Error::is_error( $res ) );
-		$this->assertSame( 'Incorrect username or password.', $res->get_message() );
+		$this->assertSame( 'Invalid Username or Password', $res->get_message() );
 
 		$res = Functions::auth( getenv( "SHIFTER_USER" ), getenv( "SHIFTER_PASS" ) );
 		$this->assertTrue( !! $res );


### PR DESCRIPTION
Now `login` api returns following response if received invalid login request.

```
{
  "message": "Invalid Username or Password"
}
```

https://apidoc.getshifter.io/#!/login/post_login

So I updated test code.